### PR TITLE
Added Calendar Support, Replaced SnackBar Library with android.support.design.widget.SnackBar Fixes #14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk: oraclejdk7
 android:
     components:
         - build-tools-22.0.1
-        - android-23
+        - android-22
         - platform-tools
         - extra-android-support
         - extra-android-m2repository

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Issues are listed here. If you have any suggestions for improvements please feel
 Read the [guidlines](https://github.com/LUGM/LUGMNotifier/blob/dev/CONTRIBUTION.md) for contribution to this app
 
 ### The app uses:
-* [Snackbar](https://github.com/nispok/snackbar) library by [William Mora](https://github.com/nispok)
 * [Picasso](https://square.github.io/picasso/) library by [Square Open Source](https://square.github.io/)
 * [Parse](http://www.parse.com) as backend
 

--- a/notifier/build.gradle
+++ b/notifier/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 22
     buildToolsVersion "21.1.2"
 
     defaultConfig {
@@ -21,10 +21,10 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:design:23.0.1'
-    compile 'com.android.support:support-v4:23.0.1'
-    compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.android.support:cardview-v7:23.0.1'
+    compile 'com.android.support:design:22.2.1'
+    compile 'com.android.support:support-v4:22.2.1'
+    compile 'com.android.support:appcompat-v7:22.2.1'
+    compile 'com.android.support:cardview-v7:22.2.1'
     compile 'com.squareup.picasso:picasso:2.4.0'
     compile 'com.parse.bolts:bolts-android:1.1.4'
 }


### PR DESCRIPTION
The EditText to set date needs to be clicked twice to get the DatePicker. No idea why this is happening. Tested on Sony Xperia Z C6602 running Android 5.1.1 and Nexus 5 running Android 5.1.1. Working on both.
