### PR TITLE
Parse initialize fix

### DIFF
--- a/notifier/src/main/java/chipset/lugmnotifier/resources/ParseInitApplication.java
+++ b/notifier/src/main/java/chipset/lugmnotifier/resources/ParseInitApplication.java
@@ -17,10 +17,10 @@ public class ParseInitApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        new Parse.Configuration.Builder(this)
+        Parse.initialize(new Parse.Configuration.Builder(this)
                 .applicationId(APPLICATION_ID)
                 .clientKey(CLIENT_KEY)
-                .server("https://parseapi.back4app.com/").build();
+                .server("https://parseapi.back4app.com/").build());
         ParsePush.subscribeInBackground("", new SaveCallback() {
             @Override
             public void done(ParseException e) {


### PR DESCRIPTION
Parse.initialize was missing in ParseInitApplication causing a crash
